### PR TITLE
Fix/commit hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,12 +70,12 @@
     ],
     "*.ts": [
       "prettier --write --single-quote true --trailing-comma all --print-width 100",
-      "tslint --fix",
+      "eslint --fix",
       "git add"
     ],
     "*.tsx": [
       "prettier --write --single-quote true --trailing-comma all --print-width 100",
-      "tslint --fix",
+      "eslint --fix",
       "git add"
     ],
     "*.yml": [

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "husky": "^3.0.2",
     "jest": "^24.7.1",
     "jest-runner-eslint": "^0.7.3",
+    "lint-staged": "^9.2.1",
     "pre-commit": "^1.2.2",
     "prettier": "^1.15.1",
     "typescript": "^3.4.5",
@@ -87,7 +88,7 @@
   "main": "index.js",
   "husky": {
     "hooks": {
-      "pre-commit": "lint:staged"
+      "pre-commit": "npm run lint:staged"
     }
   },
   "private": true,

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "eslint-plugin-react": "^7.11.1",
     "eslint-plugin-relay": "^1.3.1",
     "flow-bin": "0.98.0",
+    "husky": "^3.0.2",
     "jest": "^24.7.1",
     "jest-runner-eslint": "^0.7.3",
     "pre-commit": "^1.2.2",
@@ -84,7 +85,11 @@
     ]
   },
   "main": "index.js",
-  "pre-commit": "lint:staged",
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint:staged"
+    }
+  },
   "private": true,
   "scripts": {
     "delete:all": "yarn delete:build && yarn delete:node_modules && yarn delete:yarn-offline-cache",


### PR DESCRIPTION
# What was done?

First I've changed the `lint-staged` scripts to use eslint rather than tslint. When I commited that, got this warning:
```bash
Warning: Setting pre-commit script in package.json > scripts will be deprecated
Please move it to husky.hooks in package.json, a .huskyrc file, or a husky.config.js file
Or run ./node_modules/.bin/husky-upgrade for automatic update
```
Then I've installed [husky](https://github.com/typicode/husky/blob/master/README.md) and change the `package.json`. I configurated it to run the `npm run lint:staged` command and figured out that [lint-staged](https://github.com/okonet/lint-staged) wasn't installed. I've installed it and everything works :nerd_face:.

# Recommendations

To [work with monorepos](https://github.com/okonet/lint-staged/blob/master/README.md#how-to-use-lint-staged-in-a-multi-package-monorepo), lint-staged recommends the usage of [lerna](https://github.com/lerna/lerna) to run the packages pre-commits.