### PR TITLE
fix: change binary version of mongodb-memory-server

### DIFF
--- a/packages/server/test/environment/mongodb.js
+++ b/packages/server/test/environment/mongodb.js
@@ -13,7 +13,7 @@ class MongoDbEnvironment extends NodeEnvironment {
         // dbName: MONGO_DB_NAME,
       },
       binary: {
-        version: '4.0.0',
+        version: '4.0.10',
       },
       // debug: true,
       autoStart: false,


### PR DESCRIPTION
MongoDB Binary 4.0.0 version wasn't downloading when running `yarn workspace @entria/server test`. Change version 4.0.0 to 4.0.10.