### PR TITLE
Fix react version in web and app

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -43,6 +43,9 @@
     "relay-runtime": "^5.0.0",
     "@react-native-community/eslint-config": "^0.0.5"
   },
+  "resolutions": {
+    "react": "16.8.6"
+  },
   "private": true,
   "license": "MIT",
   "scripts": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -4,8 +4,8 @@
   "version": "1.0.0",
   "dependencies": {
     "hoist-non-react-statics": "^3.0.1",
-    "react": "^16.8.6",
-    "react-dom": "^16.8.6",
+    "react": "16.8.6",
+    "react-dom": "16.8.6",
     "react-relay": "^5.0.0",
     "rebass": "^4.0.2",
     "styled-components": "^4.2.0",
@@ -56,6 +56,10 @@
     "webpack": "^4.25.1",
     "webpack-nano": "^0.7.1",
     "webpack-plugin-serve": "^0.12.0"
+  },
+  "resolutions": {
+    "react": "16.8.6",
+    "react-dom": "16.8.6"
   },
   "main": "index.js",
   "license": "MIT",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13087,15 +13087,15 @@ react-devtools@^3.4.2:
     react-devtools-core "^3.6.0"
     update-notifier "^2.1.0"
 
-react-dom@^16.8.6:
-  version "16.9.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.9.0.tgz#5e65527a5e26f22ae3701131bcccaee9fb0d3962"
-  integrity sha512-YFT2rxO9hM70ewk9jq0y6sQk8cL02xm4+IzYBz75CQGlClQQ1Bxq0nhHF6OtSbit+AIahujJgb/CPRibFkMNJQ==
+react-dom@16.8.6:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
+  integrity sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.15.0"
+    scheduler "^0.13.6"
 
 react-hot-loader@^4.8.5:
   version "4.12.11"
@@ -14065,14 +14065,6 @@ scheduler@^0.13.6:
   version "0.13.6"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.6.tgz#466a4ec332467b31a91b9bf74e5347072e4cd889"
   integrity sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-
-scheduler@^0.15.0:
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.15.0.tgz#6bfcf80ff850b280fed4aeecc6513bc0b4f17f8e"
-  integrity sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
We had to pin the react version, as there were different versions, causing problems.

```
yarn why v1.15.2
[1/4] 🤔  Why do we have the module "react"...?
[2/4] 🚚  Initialising dependency graph...
[3/4] 🔍  Finding dependency...
[4/4] 🚡  Calculating file sizes...
=> Found "react@16.9.0"
info Has been hoisted to "react"
info Reasons this module exists
   - "workspace-aggregator-ef010c63-af9c-4727-ac01-69c1f97be1eb" depends on it
   - Hoisted from "_project_#@entria#web#react"
   - Hoisted from "_project_#@entria#web#rebass#reflexbox#react"
info Disk size without dependencies: "248KB"
info Disk size with unique dependencies: "436KB"
info Disk size with transitive dependencies: "524KB"
info Number of shared dependencies: 5
```

![image](https://user-images.githubusercontent.com/6524612/64869804-7a3eb580-d618-11e9-9867-5428192f7719.png)



